### PR TITLE
Implement renderer NDJSON ingestion module

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node bin/lights-sender",
-    "test": "node test/cli.test.js && node test/renderer-process.test.js"
+    "test": "node --test --test-concurrency=1 test/*.test.js"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node bin/lights-sender",
-    "test": "node test/cli.test.js"
+    "test": "node test/cli.test.js && node test/renderer-process.test.js"
   },
   "keywords": [],
   "author": "",

--- a/src/renderer-process/index.js
+++ b/src/renderer-process/index.js
@@ -1,0 +1,82 @@
+// Spawn and manage the external renderer process.
+//
+// The renderer is expected to write NDJSON (newline-delimited JSON)
+// frames to stdout. Each JSON object must have a `format` field of
+// "rgb8" or it will be ignored.
+const { spawn } = require('child_process');
+const readline = require('readline');
+const EventEmitter = require('events');
+
+class RendererProcess extends EventEmitter {
+  constructor(runtimeConfig, logger = console) {
+    super();
+    // Remember the configuration object and a simple logger so we can
+    // report problems to the user.
+    this.config = runtimeConfig;
+    this.logger = logger;
+    // Will hold a handle to the spawned child process.
+    this.child = null;
+  }
+
+  // Start the renderer process and wire up stdout/exit handlers.
+  start() {
+    const { cmd, args, cwd } = this.config.renderer;
+    const options = {};
+    if (cwd) {
+      // Allow the caller to control the renderer's working directory.
+      options.cwd = cwd;
+    }
+    // Spawn the renderer process with the provided command and args.
+    this.child = spawn(cmd, args, options);
+
+    // Create a line reader on the child's stdout so we get complete
+    // NDJSON objects instead of partial buffers.
+    const rl = readline.createInterface({ input: this.child.stdout });
+    rl.on('line', (line) => {
+      let parsed;
+      try {
+        // NDJSON is just JSON separated by newlines, so each line
+        // should be a complete JSON object.
+        parsed = JSON.parse(line);
+      } catch (err) {
+        // If the line isn't valid JSON we log and skip it rather than
+        // crashing the whole process.
+        this.logger.error(`Failed to parse NDJSON line: ${line}`);
+        return;
+      }
+      if (parsed.format !== 'rgb8') {
+        // The renderer might emit other formats, but for now we only
+        // understand "rgb8" frames.
+        this.logger.error(`Unsupported format: ${parsed.format}`);
+        return;
+      }
+      // Notify listeners that we have a valid frame to assemble.
+      this.emit('FrameIngest', parsed);
+    });
+
+    // If the renderer exits with a nonzero code we treat it as a crash
+    // and surface an error so the CLI can fail with the proper code.
+    this.child.on('exit', (code, signal) => {
+      if (code !== 0) {
+        const err = new Error(`Renderer exited with code ${code}${signal ? ` and signal ${signal}` : ''}`);
+        this.emit('error', err);
+      }
+    });
+
+    // Propagate other child process errors to listeners.
+    this.child.on('error', (err) => {
+      this.emit('error', err);
+    });
+
+    return this.child;
+  }
+
+  // Allow callers to stop the renderer if needed, e.g. on shutdown.
+  stop() {
+    if (this.child) {
+      this.child.kill();
+    }
+  }
+}
+
+module.exports = { RendererProcess };

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,8 +1,25 @@
-const assert = require('assert');
+// Tests for the command line interface using Node's built-in test runner.
+//
+// The test runner discovers any file ending in `.test.js` and executes the
+// exported tests. Here we verify that invoking the CLI without arguments
+// exits cleanly with status code 0.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
 const { spawnSync } = require('child_process');
 const path = require('path');
 
-const bin = path.join(__dirname, '..', 'bin', 'lights-sender');
-const result = spawnSync('node', [bin], { encoding: 'utf8' });
+test('CLI exits with code 0', () => {
+  // Resolve the path to the CLI entry point relative to this test file.
+  const bin = path.join(__dirname, '..', 'bin', 'lights-sender');
+  // Run the CLI synchronously so the test waits for it to finish.
+  const result = spawnSync('node', [bin], { encoding: 'utf8' });
+  // Assert that the process exited successfully. Include stdout/stderr in
+  // the message to help debug failures.
+  assert.strictEqual(
+    result.status,
+    0,
+    `expected exit code 0, got ${result.status}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+  );
+});
 
-assert.strictEqual(result.status, 0, `expected exit code 0, got ${result.status}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);

--- a/test/fixtures/renderer_crash.js
+++ b/test/fixtures/renderer_crash.js
@@ -1,0 +1,2 @@
+// Simulate a renderer that exits with an error code immediately.
+process.exit(1);

--- a/test/fixtures/renderer_stream.js
+++ b/test/fixtures/renderer_stream.js
@@ -1,0 +1,9 @@
+// Emit one valid frame followed by a couple of bad lines. The test
+// harness will ensure that only the valid frame is processed.
+console.log('{"ts":1,"frame":1,"fps":60,"format":"rgb8","sides":{}}');
+// This line isn't JSON at all.
+console.log('not json');
+// This line is JSON but uses an unsupported format.
+console.log('{"ts":2,"frame":2,"fps":60,"format":"hsv","sides":{}}');
+// Give the parent process a moment to read the lines before exiting.
+setTimeout(() => process.exit(0), 10);

--- a/test/renderer-process.test.js
+++ b/test/renderer-process.test.js
@@ -1,0 +1,53 @@
+const assert = require('assert');
+const path = require('path');
+const { RendererProcess } = require('../src/renderer-process');
+
+// This test spins up a fake renderer that writes a mix of good and
+// bad NDJSON lines. We verify that the good frame is ingested and that
+// errors were logged for the bad ones.
+async function testIngestAndErrors() {
+  const logs = [];
+  // Simple logger implementation that records error messages so we can
+  // make assertions about what happened.
+  const logger = { error: (msg) => logs.push(msg), warn() {}, info() {}, debug() {} };
+  const runtimeConfig = {
+    renderer: {
+      // Use Node itself to execute our small fixture script.
+      cmd: process.execPath,
+      args: [path.join(__dirname, 'fixtures', 'renderer_stream.js')],
+    },
+  };
+  const rp = new RendererProcess(runtimeConfig, logger);
+  const frames = [];
+  rp.on('FrameIngest', (frame) => frames.push(frame));
+  const child = rp.start();
+  // Wait for the fixture process to finish writing its lines.
+  await new Promise((resolve) => child.on('close', resolve));
+  assert.strictEqual(frames.length, 1, `expected 1 frame, got ${frames.length}`);
+  assert.strictEqual(frames[0].frame, 1);
+  // Ensure our logger caught parse and format errors.
+  assert(logs.some((l) => l.includes('Failed to parse NDJSON line')));
+  assert(logs.some((l) => l.includes('Unsupported format')));
+}
+
+// This test uses a renderer that exits immediately with a nonzero code.
+// The RendererProcess should surface this as an error event.
+async function testCrashEmitsError() {
+  const runtimeConfig = {
+    renderer: {
+      cmd: process.execPath,
+      args: [path.join(__dirname, 'fixtures', 'renderer_crash.js')],
+    },
+  };
+  const rp = new RendererProcess(runtimeConfig, console);
+  const err = await new Promise((resolve) => {
+    rp.on('error', resolve);
+    rp.start();
+  });
+  assert(err instanceof Error);
+}
+
+(async () => {
+  await testIngestAndErrors();
+  await testCrashEmitsError();
+})();


### PR DESCRIPTION
## Summary
- add renderer-process module spawning renderer, parsing NDJSON lines, and emitting FrameIngest events
- log malformed lines and unsupported formats, emit error on renderer exit
- introduce tests for frame ingestion and crash handling
- add explanatory comments throughout the module and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae90c5926c83229fce03117e678eb4