### PR TITLE
feat: assemble run buffers from NDJSON frames

### DIFF
--- a/src/assembler/README.md
+++ b/src/assembler/README.md
@@ -1,0 +1,5 @@
+# Assembler
+
+Listens for `FrameIngest` events and builds per-run RGB buffers for each configured side.
+Base64 `rgb_b64` section data are decoded into `Uint8Array` run buffers.
+Successful assemblies emit `FrameAssembled` events for downstream consumers.

--- a/src/assembler/index.mjs
+++ b/src/assembler/index.mjs
@@ -1,0 +1,92 @@
+import { EventEmitter } from 'events';
+
+/**
+ * Assembler listens for NDJSON frame events and builds per-run RGB buffers.
+ * It decodes base64-encoded section data into Uint8Array buffers and
+ * emits a FrameAssembled event for each side that assembles successfully.
+ */
+export class Assembler extends EventEmitter {
+  /**
+   * @param {object} runtimeConfig - Loaded sender configuration containing side layouts.
+   * @param {{error:Function, warn:Function, info:Function, debug:Function}} [logger=console] - Logger for diagnostics.
+   */
+  constructor(runtimeConfig, logger = console) {
+    super();
+    this.config = runtimeConfig;
+    this.logger = logger;
+  }
+
+  /**
+   * Bind to an EventEmitter that emits FrameIngest events with NDJSON frames.
+   * @param {EventEmitter} frameEmitter
+   */
+  bindFrameEmitter(frameEmitter) {
+    frameEmitter.on('FrameIngest', (ndjsonFrame) => {
+      this.#handleFrame(ndjsonFrame);
+    });
+  }
+
+  /**
+   * Handle a single NDJSON frame and emit assembled buffers.
+   * @param {object} ndjsonFrame
+   */
+  #handleFrame(ndjsonFrame) {
+    const sides = this.config.sides || {};
+    for (const [sideName, sideConfig] of Object.entries(sides)) {
+      if (!sideConfig) {
+        continue;
+      }
+      const frameSides = ndjsonFrame.sides || {};
+      const frameSide = frameSides[sideName];
+      if (!frameSide) {
+        continue;
+      }
+
+      const runBuffers = [];
+      let sideIsValid = true;
+
+      for (const runConfig of sideConfig.runs) {
+        const runBuffer = new Uint8Array(runConfig.led_count * 3);
+        let bufferOffset = 0;
+
+        for (const sectionConfig of runConfig.sections) {
+          const sectionFrame = frameSide[sectionConfig.id];
+          if (!sectionFrame) {
+            this.logger.error(`Missing section ${sectionConfig.id} for side ${sideName}`);
+            sideIsValid = false;
+            break;
+          }
+
+          const decodedSection = Buffer.from(sectionFrame.rgb_b64, 'base64');
+          const expectedBytes = sectionConfig.led_count * 3;
+          if (decodedSection.length !== expectedBytes) {
+            this.logger.error(
+              `Section ${sectionConfig.id} length mismatch for side ${sideName}`,
+            );
+            sideIsValid = false;
+            break;
+          }
+
+          runBuffer.set(decodedSection, bufferOffset);
+          bufferOffset += expectedBytes;
+        }
+
+        if (!sideIsValid) {
+          break;
+        }
+
+        runBuffers.push({ run_index: runConfig.run_index, data: runBuffer });
+      }
+
+      if (sideIsValid) {
+        this.emit('FrameAssembled', {
+          side: sideConfig.side || sideName,
+          frame_id: ndjsonFrame.frame >>> 0,
+          runs: runBuffers,
+        });
+      }
+    }
+  }
+}
+
+export default Assembler;

--- a/test/assembler.test.mjs
+++ b/test/assembler.test.mjs
@@ -1,0 +1,98 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'events';
+import { Assembler } from '../src/assembler/index.mjs';
+
+test('assembles run buffers and emits FrameAssembled', () => {
+  const frameEmitter = new EventEmitter();
+  const layout = {
+    side: 'left',
+    total_leds: 3,
+    runs: [
+      {
+        run_index: 0,
+        led_count: 3,
+        sections: [
+          { id: 'row_A1', led_count: 2 },
+          { id: 'row_A2', led_count: 1 },
+        ],
+      },
+    ],
+  };
+  const runtimeConfig = { sides: { left: layout } };
+  const assembler = new Assembler(runtimeConfig, console);
+  assembler.bindFrameEmitter(frameEmitter);
+
+  const assembledFrames = [];
+  assembler.on('FrameAssembled', (assembled) => assembledFrames.push(assembled));
+
+  const frame = {
+    frame: 7,
+    sides: {
+      left: {
+        row_A1: { length: 2, rgb_b64: Buffer.from([1,2,3,4,5,6]).toString('base64') },
+        row_A2: { length: 1, rgb_b64: Buffer.from([7,8,9]).toString('base64') },
+      },
+    },
+  };
+  frameEmitter.emit('FrameIngest', frame);
+
+  assert.strictEqual(assembledFrames.length, 1);
+  assert.strictEqual(assembledFrames[0].frame_id, 7);
+  assert.deepStrictEqual(
+    Array.from(assembledFrames[0].runs[0].data),
+    [1,2,3,4,5,6,7,8,9],
+  );
+});
+
+test('drops side when sections are missing or mismatched', () => {
+  const frameEmitter = new EventEmitter();
+  const layout = {
+    side: 'left',
+    total_leds: 3,
+    runs: [
+      {
+        run_index: 0,
+        led_count: 3,
+        sections: [
+          { id: 'row_A1', led_count: 2 },
+          { id: 'row_A2', led_count: 1 },
+        ],
+      },
+    ],
+  };
+  const loggerMessages = [];
+  const logger = {
+    error: (msg) => loggerMessages.push(msg),
+    warn() {},
+    info() {},
+    debug() {},
+  };
+  const runtimeConfig = { sides: { left: layout } };
+  const assembler = new Assembler(runtimeConfig, logger);
+  assembler.bindFrameEmitter(frameEmitter);
+
+  const assembledFrames = [];
+  assembler.on('FrameAssembled', (assembled) => assembledFrames.push(assembled));
+
+  // Missing second section
+  frameEmitter.emit('FrameIngest', {
+    frame: 1,
+    sides: { left: { row_A1: { length: 2, rgb_b64: Buffer.from([1,2,3,4,5,6]).toString('base64') } } },
+  });
+
+  // Length mismatch
+  frameEmitter.emit('FrameIngest', {
+    frame: 2,
+    sides: {
+      left: {
+        row_A1: { length: 2, rgb_b64: Buffer.from([1,2,3]).toString('base64') },
+        row_A2: { length: 1, rgb_b64: Buffer.from([4,5,6]).toString('base64') },
+      },
+    },
+  });
+
+  assert.strictEqual(assembledFrames.length, 0);
+  assert(loggerMessages.some((m) => m.includes('Missing section')));
+  assert(loggerMessages.some((m) => m.includes('length mismatch')));
+});


### PR DESCRIPTION
## Summary
- decode base64 section data into run buffers
- emit assembled frames per side for downstream consumers
- add tests covering assembly success and drop logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aea21c54c48322912a2d9def5e55bc