### PR TITLE
Add mailbox and UDP sender modules

### DIFF
--- a/src/assembler/README.md
+++ b/src/assembler/README.md
@@ -2,4 +2,5 @@
 
 Listens for `FrameIngest` events and builds per-run RGB buffers for each configured side.
 Base64 `rgb_b64` section data are decoded into `Uint8Array` run buffers.
-Successful assemblies emit `FrameAssembled` events for downstream consumers.
+Successful assemblies emit `FrameAssembled` events for downstream consumers and
+optionally write frames into a [`Mailbox`](../mailbox) when one is supplied.

--- a/src/assembler/index.mjs
+++ b/src/assembler/index.mjs
@@ -9,11 +9,13 @@ export class Assembler extends EventEmitter {
   /**
    * @param {object} runtimeConfig - Loaded sender configuration containing side layouts.
    * @param {{error:Function, warn:Function, info:Function, debug:Function}} [logger=console] - Logger for diagnostics.
+   * @param {object} [mailbox] - Optional mailbox for assembled frames.
    */
-  constructor(runtimeConfig, logger = console) {
+  constructor(runtimeConfig, logger = console, mailbox = null) {
     super();
     this.config = runtimeConfig;
     this.logger = logger;
+    this.mailbox = mailbox;
   }
 
   /**
@@ -79,11 +81,15 @@ export class Assembler extends EventEmitter {
       }
 
       if (sideIsValid) {
-        this.emit('FrameAssembled', {
+        const assembled = {
           side: sideConfig.side || sideName,
           frame_id: ndjsonFrame.frame >>> 0,
           runs: runBuffers,
-        });
+        };
+        this.emit('FrameAssembled', assembled);
+        if (this.mailbox) {
+          this.mailbox.write(sideConfig.side || sideName, assembled);
+        }
       }
     }
   }

--- a/src/mailbox/README.md
+++ b/src/mailbox/README.md
@@ -1,0 +1,35 @@
+# Mailbox
+
+Provides single-slot storage for assembled frames per side.
+The assembler writes completed frames for the left and right sides
+and the UDP sender retrieves them when ready to transmit.
+
+## Usage
+
+```ts
+import { Mailbox } from './mailbox';
+
+const mailbox = new Mailbox();
+
+// Assembler writes frames
+mailbox.write('left', assembledFrame);
+
+// UDP sender reads frames
+const frame = mailbox.take('left');
+```
+
+## Lifecycle and Flow
+1. `Assembler` decodes NDJSON input into `AssembledFrame` objects.
+2. After a side is built, it calls `mailbox.write(side, frame)` which overwrites any
+   previously stored frame for that side.
+3. `UdpSender` continuously polls `mailbox.take(side)`; when a frame is present it is
+   removed from the mailbox and sent over the network.
+
+## Concurrency Guarantees
+- Each side has a single storage slot.
+- `write` overwrites the slot atomically. If a frame was present and not yet read,
+  `frames_dropped_overwrite` is incremented.
+- `take` retrieves and clears the slot atomically. If a frame was read,
+  `frames_sent` is incremented.
+- No locking is required as Node.js runs JavaScript in a single thread, ensuring
+  that `write` and `take` operations complete without interruption.

--- a/src/mailbox/index.ts
+++ b/src/mailbox/index.ts
@@ -1,0 +1,54 @@
+export interface AssembledFrame {
+  side: string;
+  frame_id: number;
+  runs: { run_index: number; data: Uint8Array }[];
+}
+
+type Side = 'left' | 'right';
+
+interface Slot {
+  frame?: AssembledFrame;
+  frames_dropped_overwrite: number;
+  frames_sent: number;
+}
+
+/**
+ * Mailbox provides single-slot storage for assembled frames per side.
+ * Writers overwrite any existing frame while readers atomically take and clear.
+ */
+export class Mailbox {
+  private slots: Record<Side, Slot>;
+
+  constructor() {
+    this.slots = {
+      left: { frames_dropped_overwrite: 0, frames_sent: 0 },
+      right: { frames_dropped_overwrite: 0, frames_sent: 0 },
+    };
+  }
+
+  /** Store the latest frame for a side, overwriting any existing frame. */
+  write(side: Side, frame: AssembledFrame): void {
+    const slot = this.slots[side];
+    if (slot.frame) {
+      slot.frames_dropped_overwrite += 1;
+    }
+    slot.frame = frame;
+  }
+
+  /** Atomically take and clear the stored frame for a side. */
+  take(side: Side): AssembledFrame | undefined {
+    const slot = this.slots[side];
+    const frame = slot.frame;
+    if (frame) {
+      slot.frames_sent += 1;
+      slot.frame = undefined;
+    }
+    return frame;
+  }
+
+  /** Retrieve telemetry counters for a side. */
+  stats(side: Side): { frames_dropped_overwrite: number; frames_sent: number } {
+    const { frames_dropped_overwrite, frames_sent } = this.slots[side];
+    return { frames_dropped_overwrite, frames_sent };
+  }
+}

--- a/src/udp-sender/README.md
+++ b/src/udp-sender/README.md
@@ -1,0 +1,23 @@
+# UDP Sender
+
+Fetches frames from the [Mailbox](../mailbox) and sends them to each side's
+controller over UDP. One loop runs per side, polling the mailbox and emitting a
+packet for each run within a frame.
+
+## Usage
+
+```js
+import { Mailbox } from '../mailbox/index.ts';
+import { UdpSender } from './index.mjs';
+
+const mailbox = new Mailbox();
+const sender = new UdpSender(runtimeConfig, mailbox);
+sender.start();
+
+// later when shutting down
+sender.stop();
+```
+
+`UdpSender` calls `mailbox.take(side)` which atomically retrieves the latest
+assembled frame. The mailbox updates telemetry counters (`frames_sent`) when
+frames are consumed.

--- a/src/udp-sender/index.mjs
+++ b/src/udp-sender/index.mjs
@@ -1,0 +1,74 @@
+import dgram from 'dgram';
+
+/**
+ * UdpSender polls the mailbox for assembled frames and sends them via UDP.
+ */
+export class UdpSender {
+  /**
+   * @param {object} runtimeConfig - Loaded sender configuration
+   * @param {Mailbox} mailbox - Mailbox instance for retrieving frames
+   * @param {{error:Function, warn:Function, info:Function, debug:Function}} [logger=console]
+   */
+  constructor(runtimeConfig, mailbox, logger = console) {
+    this.config = runtimeConfig;
+    this.mailbox = mailbox;
+    this.logger = logger;
+    this.sockets = {};
+    this.timers = {};
+  }
+
+  /** Start polling loops for all configured sides. */
+  start() {
+    const sides = this.config.sides || {};
+    for (const [sideName, sideConfig] of Object.entries(sides)) {
+      const socket = dgram.createSocket('udp4');
+      this.sockets[sideName] = socket;
+      this.timers[sideName] = setInterval(
+        () => this.#sendAvailable(sideName, sideConfig, socket),
+        1,
+      );
+    }
+  }
+
+  /** Stop all loops and close sockets. */
+  stop() {
+    for (const timer of Object.values(this.timers)) {
+      clearInterval(timer);
+    }
+    for (const socket of Object.values(this.sockets)) {
+      socket.close();
+    }
+  }
+
+  /**
+   * Check the mailbox for a frame and send packets for each run.
+   * @param {"left"|"right"} sideName
+   * @param {object} sideConfig
+   * @param {import('dgram').Socket} socket
+   */
+  #sendAvailable(sideName, sideConfig, socket) {
+    const frame = this.mailbox.take(sideName);
+    if (!frame) {
+      return;
+    }
+    for (const run of frame.runs) {
+      const header = Buffer.alloc(4);
+      header.writeUInt32BE(frame.frame_id >>> 0, 0);
+      const packet = Buffer.concat([header, run.data]);
+      socket.send(
+        packet,
+        sideConfig.portBase + run.run_index,
+        sideConfig.ip,
+        (err) => {
+          if (err) {
+            this.logger.error(
+              `UDP send error for side ${sideName}: ${err.message}`,
+            );
+          }
+        },
+      );
+    }
+  }
+}
+
+export default UdpSender;


### PR DESCRIPTION
## Summary
- Implement mailbox with atomic slots for left/right frames and telemetry counters
- Integrate assembler with mailbox writes and add UDP sender polling loop
- Document mailbox usage and UDP sender flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aea768f2908322b9704ca4c8860646