### PR TITLE
Add integration tests using looped renderer

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,16 @@
+# Tests
+
+Integration and unit tests for the Barn Lights UDP Sender. The tests run with Node's built-in test runner and exercise both individual modules and end-to-end behavior.
+
+## Fixtures
+- `renderer_stream.mjs` emits a short sequence of frames including malformed lines.
+- `renderer_crash.mjs` simulates a renderer that exits with an error.
+- `renderer_loop.mjs` continuously streams frames from `config/input-sample.txt` for integration testing.
+
+## Test Files
+- `assembler.test.mjs` verifies frame assembly logic.
+- `cli-layout.test.mjs` covers CLI layout handling.
+- `cli.test.mjs` ensures the command-line interface starts and stops cleanly.
+- `integration.test.mjs` runs a mock renderer in a loop and validates the full pipeline through UDP transmission.
+- `layout.test.mjs` checks layout validation.
+- `renderer-process.test.mjs` exercises renderer spawning and NDJSON ingestion.

--- a/test/fixtures/renderer_loop.mjs
+++ b/test/fixtures/renderer_loop.mjs
@@ -1,0 +1,13 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const inputPath = process.argv[2] || path.join(__dirname, '..', '..', 'config', 'input-sample.txt');
+const lines = fs.readFileSync(inputPath, 'utf8').trim().split('\n');
+let index = 0;
+setInterval(() => {
+  process.stdout.write(lines[index] + '\n');
+  index = (index + 1) % lines.length;
+}, 10);

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import fs from 'fs';
+import dgram from 'dgram';
+import { fileURLToPath } from 'url';
+import { RendererProcess } from '../src/renderer-process/index.mjs';
+import { Assembler } from '../src/assembler/index.mjs';
+import { Mailbox } from '../src/mailbox/index.mjs';
+import { UdpSender } from '../src/udp-sender/index.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const layoutPath = path.join(__dirname, '..', 'config', 'left.json');
+const leftLayout = JSON.parse(fs.readFileSync(layoutPath, 'utf8'));
+
+function buildConfig(portBase) {
+  return {
+    renderer: {
+      cmd: process.execPath,
+      args: [path.join(__dirname, 'fixtures', 'renderer_loop.mjs')],
+    },
+    sides: {
+      left: {
+        ...leftLayout,
+        ip: '127.0.0.1',
+        portBase,
+      },
+    },
+  };
+}
+
+test('assembler writes frames from looped renderer into mailbox', async () => {
+  const runtimeConfig = buildConfig(50000);
+  const mailbox = new Mailbox();
+  const renderer = new RendererProcess(runtimeConfig);
+  renderer.on('error', () => {});
+  const assembler = new Assembler(runtimeConfig, console, mailbox);
+  assembler.bindFrameEmitter(renderer);
+
+  renderer.start();
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  renderer.stop();
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  const frame = mailbox.take('left');
+  assert(frame, 'expected mailbox to contain an assembled frame');
+  assert.strictEqual(frame.runs.length, leftLayout.runs.length);
+});
+
+test('udp sender transmits packets for assembled frames', async () => {
+  const udpServer = dgram.createSocket('udp4');
+  await new Promise((resolve) => udpServer.bind(0, resolve));
+  const portBase = udpServer.address().port;
+  const runtimeConfig = buildConfig(portBase);
+  const mailbox = new Mailbox();
+  const renderer = new RendererProcess(runtimeConfig);
+  renderer.on('error', () => {});
+  const assembler = new Assembler(runtimeConfig, console, mailbox);
+  assembler.bindFrameEmitter(renderer);
+  const sender = new UdpSender(runtimeConfig, mailbox);
+
+  const receivedPackets = [];
+  udpServer.on('message', (msg) => receivedPackets.push(msg));
+
+  renderer.start();
+  sender.start();
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  sender.stop();
+  renderer.stop();
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  udpServer.close();
+
+  assert(receivedPackets.length > 0, 'expected at least one UDP packet');
+  const expectedLength = 4 + leftLayout.runs[0].led_count * 3;
+  assert.strictEqual(receivedPackets[0].length, expectedLength);
+});


### PR DESCRIPTION
## Summary
- add renderer fixture that loops sample NDJSON frames
- introduce integration tests to verify assembly and UDP transmission
- document test suite structure and fixtures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aec3ce34808322b4aed41d6b159854