### PR TITLE
Add demo renderer and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@ Options:
 The process continues running until it receives `SIGINT` or `SIGTERM`, at which point
 the renderer and UDP sender shut down cleanly.
 
+### Demo Renderer
+
+For development and testing a demo renderer is provided that continuously emits
+NDJSON frames. Run the sender with the demo configuration:
+
+```bash
+npm start -- --config ./config/demo.config.json
+```
+
+Telemetry appears in the terminal:
+
+```
+side ingested built sent drop_build drop_overwrite  pps      Bps last_frame                last_send
+left       25    25   25          0              0 75.0  90300.0         24 2025-08-27T16:52:19.867Z
+right      25    25   25          0              0 75.0 112800.0         24 2025-08-27T16:52:19.867Z
+```
+
+Use `Ctrl+C` to stop the sender and demo renderer.
+
 ## Exit Codes
 
 - `0` Normal shutdown.

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,6 @@
+# Bin Scripts
+
+Executable scripts and helper utilities.
+
+- `lights-sender.mjs` - CLI entry that loads configuration and starts the UDP sender.
+- `demo-renderer.mjs` - Development renderer that emits NDJSON frames at a configurable frame rate.

--- a/bin/demo-renderer.mjs
+++ b/bin/demo-renderer.mjs
@@ -1,0 +1,57 @@
+import fs from 'fs';
+
+function parseFramesPerSecond() {
+  const args = process.argv.slice(2);
+  const flagIndex = args.indexOf('--fps');
+  if (flagIndex !== -1 && args[flagIndex + 1]) {
+    const value = Number(args[flagIndex + 1]);
+    if (!Number.isNaN(value) && value > 0) {
+      return value;
+    }
+  }
+  return 1;
+}
+
+function loadLayout(path) {
+  const url = new URL(path, import.meta.url);
+  return JSON.parse(fs.readFileSync(url, 'utf8'));
+}
+
+const layouts = {
+  left: loadLayout('../config/left.json'),
+  right: loadLayout('../config/right.json')
+};
+
+function buildSide(layout, frameId) {
+  const sections = {};
+  for (const run of layout.runs) {
+    for (const section of run.sections) {
+      const { id, led_count } = section;
+      const buffer = Buffer.alloc(led_count * 3);
+      for (let i = 0; i < led_count; i += 1) {
+        buffer[i * 3] = frameId % 256;
+      }
+      sections[id] = { rgb_b64: buffer.toString('base64') };
+    }
+  }
+  return sections;
+}
+
+const fps = parseFramesPerSecond();
+const intervalMs = 1000 / fps;
+let frameId = 0;
+
+setInterval(() => {
+  const frame = {
+    ts: Math.floor(Date.now() / 1000),
+    frame: frameId,
+    fps,
+    format: 'rgb8',
+    sides: {
+      left: buildSide(layouts.left, frameId),
+      right: buildSide(layouts.right, frameId)
+    }
+  };
+  process.stdout.write(`${JSON.stringify(frame)}\n`);
+  frameId += 1;
+}, intervalMs);

--- a/config/demo.config.json
+++ b/config/demo.config.json
@@ -1,0 +1,84 @@
+{
+  "sides": {
+    "left": {
+      "ip": "127.0.0.1",
+      "portBase": 49600,
+      "side": "left",
+      "total_leds": 1200,
+      "runs": [
+        {
+          "run_index": 0,
+          "led_count": 400,
+          "sections": [
+            { "id": "row_A1", "led_count": 180, "y": 0.18, "x0": 0.0, "x1": 0.20 },
+            { "id": "row_A2", "led_count": 120, "y": 0.22, "x0": 0.20,  "x1": 1.35 },
+            { "id": "row_A3", "led_count": 100,  "y": 0.26, "x0": 0.75,  "x1": 1.80 }
+          ]
+        },
+        {
+          "run_index": 1,
+          "led_count": 400,
+          "sections": [
+            { "id": "row_B1", "led_count": 140, "y": 0.50, "x0": 0.00,  "x1": 1.00 },
+            { "id": "row_B2", "led_count": 120, "y": 0.55, "x0": 0.60,  "x1": 1.60 },
+            { "id": "row_B3", "led_count": 140, "y": 0.58, "x0": 0.10, "x1": 0.90 }
+          ]
+        },
+        {
+          "run_index": 2,
+          "led_count": 400,
+          "sections": [
+            { "id": "row_C1", "led_count": 150, "y": 0.78, "x0": 0.25,  "x1": 1.30 },
+            { "id": "row_C2", "led_count": 130, "y": 0.82, "x0": 0.00,  "x1": 1.10 },
+            { "id": "row_C3", "led_count": 120, "y": 0.88, "x0": 1.00,  "x1": 2.00 }
+          ]
+        }
+      ],
+      "sampling": { "space": "normalized", "width": 2.0, "height": 1.0 }
+    },
+    "right": {
+      "ip": "127.0.0.1",
+      "portBase": 49610,
+      "side": "right",
+      "total_leds": 1500,
+      "runs": [
+        {
+          "run_index": 0,
+          "led_count": 500,
+          "sections": [
+            { "id": "row_A1", "led_count": 200, "y": 0.12, "x0": 0.05, "x1": 0.85 },
+            { "id": "row_A2", "led_count": 180, "y": 0.18, "x0": 0.90, "x1": 1.70 },
+            { "id": "row_A3", "led_count": 120, "y": 0.24, "x0": 0.20, "x1": 1.50 }
+          ]
+        },
+        {
+          "run_index": 1,
+          "led_count": 500,
+          "sections": [
+            { "id": "row_B1", "led_count": 160, "y": 0.45, "x0": 0.00, "x1": 1.00 },
+            { "id": "row_B2", "led_count": 170, "y": 0.52, "x0": 0.75, "x1": 1.95 },
+            { "id": "row_B3", "led_count": 170, "y": 0.60, "x0": 0.30, "x1": 1.20 }
+          ]
+        },
+        {
+          "run_index": 2,
+          "led_count": 500,
+          "sections": [
+            { "id": "row_C1", "led_count": 190, "y": 0.78, "x0": 0.10, "x1": 1.40 },
+            { "id": "row_C2", "led_count": 160, "y": 0.84, "x0": 0.60, "x1": 1.80 },
+            { "id": "row_C3", "led_count": 150, "y": 0.90, "x0": 1.10, "x1": 2.00 }
+          ]
+        }
+      ],
+      "sampling": { "space": "normalized", "width": 2.0, "height": 1.0 }
+    }
+  },
+  "renderer": {
+    "cmd": "node",
+    "args": ["./bin/demo-renderer.mjs", "--fps", "30"]
+  },
+  "telemetry": {
+    "interval_ms": 1000,
+    "log_level": "info"
+  }
+}


### PR DESCRIPTION
## Summary
- add demo renderer script that outputs NDJSON frames at a configurable frame rate
- provide demo configuration pointing at the new renderer
- document demo usage and telemetry output in the README

## Testing
- `npm test`
- `npm start -- --config ./config/demo.config.json`

------
https://chatgpt.com/codex/tasks/task_e_68af36b56608832297c8204819713531