### PR TITLE
Expose layout runs at top-level config

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -72,7 +72,9 @@ export async function main(argv = process.argv) {
           if (!fs.existsSync(layoutPath)) {
             layoutPath = path.resolve(process.cwd(), cfg.layout);
           }
-          cfg.layout = loadLayout(layoutPath, logger);
+          const layout = loadLayout(layoutPath, logger);
+          Object.assign(cfg, layout);     // merge runs/total_leds/side into cfg
+          cfg.layout = layout; // keep layout for reference only
           logger.debug(`Loaded ${side} layout from ${layoutPath}`);
         }
       }


### PR DESCRIPTION
## Summary
- Merge loaded layout properties into each side's config, exposing `runs`, `total_leds`, and `side` directly while retaining the layout object for reference.

## Testing
- `npm test`
- `node bin/lights-sender.mjs --config config/sender.config.json` (with dummy renderer)

------
https://chatgpt.com/codex/tasks/task_e_68af39d194a88322a9fa7366f2f9a063