### PR TITLE
Verify UDP packet headers and payloads

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -7,6 +7,7 @@ Integration and unit tests for the Barn Lights UDP Sender. The tests run with No
 - `renderer_crash.mjs` simulates a renderer that exits with an error.
 - `renderer_loop.mjs` continuously streams frames from `config/input-sample.txt` for integration testing.
 - `renderer_preamble.mjs` prints startup messages before emitting the first frame to test preamble handling.
+- `decode-sample-frame.mjs` decodes the first sample frame into a run buffer for assertions.
 
 ## Test Files
 - `assembler.test.mjs` verifies frame assembly logic.

--- a/test/fixtures/decode-sample-frame.mjs
+++ b/test/fixtures/decode-sample-frame.mjs
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Decode the first frame from the renderer sample and assemble the
+ * expected RGB buffer for the first run of the left side.
+ * @param {string} layoutPath - Path to the layout JSON file for the side.
+ * @param {string} samplePath - Optional path to the renderer sample input.
+ * @returns {{frameId:number, buffer:Buffer}}
+ */
+export function decodeSampleFrame(layoutPath, samplePath = path.join(__dirname, '..', '..', 'config', 'input-sample.txt')) {
+  const ndjsonLine = fs.readFileSync(samplePath, 'utf8').split('\n')[0];
+  const frame = JSON.parse(ndjsonLine);
+  const layout = JSON.parse(fs.readFileSync(layoutPath, 'utf8'));
+  const runConfig = layout.runs[0];
+  const frameSide = frame.sides.left;
+  const buffer = Buffer.alloc(runConfig.led_count * 3);
+  let offset = 0;
+  for (const section of runConfig.sections) {
+    const sectionFrame = frameSide[section.id];
+    const decoded = Buffer.from(sectionFrame.rgb_b64, 'base64');
+    buffer.set(decoded, offset);
+    offset += decoded.length;
+  }
+  return { frameId: frame.frame >>> 0, buffer };
+}


### PR DESCRIPTION
## Summary
- add helper to decode renderer sample frame
- parse first UDP packet in integration test, verifying frame ID and RGB payload
- document new decoding helper in test fixtures README

## Testing
- `npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68af61e740e8832291a9ba871667147d