### PR TITLE
Add configuration loader with validation

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { loadLayout } from './config/load-layout.mjs';
+import { loadConfig, validateLogLevel } from './config/load-config.mjs';
 import { RendererProcess } from './renderer-process/index.mjs';
 import { Mailbox } from './mailbox/index.mjs';
 import { Assembler } from './assembler/index.mjs';
@@ -20,22 +21,6 @@ function parseArgs(argv) {
   return result;
 }
 
-function validateLogLevel(level) {
-  return level === 'error' || level === 'warn' || level === 'info' || level === 'debug';
-}
-
-function loadConfig(configPath) {
-  const raw = fs.readFileSync(configPath, 'utf8');
-  const parsed = JSON.parse(raw);
-  if (!parsed.telemetry) {
-    throw new Error('Missing telemetry configuration');
-  }
-  const lvl = parsed.telemetry.log_level;
-  if (lvl && !validateLogLevel(lvl)) {
-    throw new Error(`Invalid telemetry.log_level: ${lvl}`);
-  }
-  return parsed;
-}
 
 function createLogger(level) {
   const order = { error: 0, warn: 1, info: 2, debug: 3 };

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -1,3 +1,6 @@
 # Config
 
 Utilities for loading sender configuration and side layout files.
+
+- `load-config.mjs` parses `sender.config.json` and validates renderer, side, and telemetry settings.
+- `load-layout.mjs` reads a layout JSON file and validates its structure.

--- a/src/config/load-config.mjs
+++ b/src/config/load-config.mjs
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+
+export function validateLogLevel(level) {
+  return level === 'error' || level === 'warn' || level === 'info' || level === 'debug';
+}
+
+export function loadConfig(configPath) {
+  const rawConfig = fs.readFileSync(configPath, 'utf8');
+  const parsedConfig = JSON.parse(rawConfig);
+
+  if (!parsedConfig.renderer || typeof parsedConfig.renderer.cmd !== 'string' || parsedConfig.renderer.cmd.length === 0) {
+    throw new Error('renderer.cmd must be a non-empty string');
+  }
+  if (!Array.isArray(parsedConfig.renderer.args)) {
+    throw new Error('renderer.args must be an array');
+  }
+
+  if (!parsedConfig.sides || typeof parsedConfig.sides !== 'object') {
+    throw new Error('Missing sides configuration');
+  }
+  const baseDirectory = path.dirname(configPath);
+  for (const [sideName, sideConfig] of Object.entries(parsedConfig.sides)) {
+    if (typeof sideConfig.ip !== 'string') {
+      throw new Error(`side ${sideName} ip must be a string`);
+    }
+    if (typeof sideConfig.portBase !== 'number') {
+      throw new Error(`side ${sideName} portBase must be a number`);
+    }
+    if (typeof sideConfig.layout !== 'string') {
+      throw new Error(`side ${sideName} layout must be a string`);
+    }
+    let layoutPath = path.resolve(baseDirectory, sideConfig.layout);
+    if (!fs.existsSync(layoutPath)) {
+      layoutPath = path.resolve(process.cwd(), sideConfig.layout);
+      if (!fs.existsSync(layoutPath)) {
+        throw new Error(`Layout file not found for side ${sideName}: ${sideConfig.layout}`);
+      }
+    }
+  }
+
+  if (!parsedConfig.telemetry) {
+    throw new Error('Missing telemetry configuration');
+  }
+  const interval = parsedConfig.telemetry.interval_ms;
+  if (!Number.isInteger(interval) || interval <= 0) {
+    throw new Error('telemetry.interval_ms must be a positive integer');
+  }
+  const logLevel = parsedConfig.telemetry.log_level;
+  if (logLevel && !validateLogLevel(logLevel)) {
+    throw new Error(`Invalid telemetry.log_level: ${logLevel}`);
+  }
+
+  return parsedConfig;
+}

--- a/test/README.md
+++ b/test/README.md
@@ -11,6 +11,7 @@ Integration and unit tests for the Barn Lights UDP Sender. The tests run with No
 ## Test Files
 - `assembler.test.mjs` verifies frame assembly logic.
 - `cli-layout.test.mjs` covers CLI layout handling.
+- `cli-config.test.mjs` verifies configuration validation logic.
 - `cli.test.mjs` ensures the command-line interface starts and stops cleanly.
 - `integration.test.mjs` runs a mock renderer in a loop and validates the full pipeline through UDP transmission.
 - `layout.test.mjs` checks layout validation.

--- a/test/cli-config.test.mjs
+++ b/test/cli-config.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { spawn, spawnSync } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const binaryPath = path.join(__dirname, '..', 'bin', 'lights-sender.mjs');
+const baseConfigPath = path.join(__dirname, 'fixtures', 'cli_renderer.config.json');
+const baseConfig = JSON.parse(fs.readFileSync(baseConfigPath, 'utf8'));
+
+function writeTempConfig(mutator) {
+  const configObject = JSON.parse(JSON.stringify(baseConfig));
+  mutator(configObject);
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'cfg-'));
+  const filePath = path.join(temporaryDirectory, 'sender.config.json');
+  fs.writeFileSync(filePath, JSON.stringify(configObject));
+  return filePath;
+}
+
+test('CLI accepts a valid configuration', async () => {
+  const child = spawn('node', [binaryPath, '--config', baseConfigPath], { stdio: 'pipe' });
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  child.kill('SIGINT');
+  const exitCode = await new Promise((resolve) => {
+    child.on('exit', (code) => resolve(code));
+  });
+  assert.strictEqual(exitCode, 0);
+});
+
+test('CLI fails when renderer command is missing', () => {
+  const badPath = writeTempConfig((cfg) => { delete cfg.renderer.cmd; });
+  const result = spawnSync('node', [binaryPath, '--config', badPath], { encoding: 'utf8' });
+  assert.strictEqual(result.status, 1);
+});
+
+test('CLI fails when side portBase is not numeric', () => {
+  const badPath = writeTempConfig((cfg) => { cfg.sides.left.portBase = 'abc'; });
+  const result = spawnSync('node', [binaryPath, '--config', badPath], { encoding: 'utf8' });
+  assert.strictEqual(result.status, 1);
+});
+
+test('CLI fails when telemetry interval is non-positive', () => {
+  const badPath = writeTempConfig((cfg) => { cfg.telemetry.interval_ms = 0; });
+  const result = spawnSync('node', [binaryPath, '--config', badPath], { encoding: 'utf8' });
+  assert.strictEqual(result.status, 1);
+});
+
+test('CLI fails when telemetry log level is invalid', () => {
+  const badPath = writeTempConfig((cfg) => { cfg.telemetry.log_level = 'verbose'; });
+  const result = spawnSync('node', [binaryPath, '--config', badPath], { encoding: 'utf8' });
+  assert.strictEqual(result.status, 1);
+});


### PR DESCRIPTION
## Summary
- add loadConfig module with renderer, side and telemetry validation
- replace CLI loadConfig with reusable module
- test CLI config handling for valid and invalid inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af631845a48322a7fbd711c0602356