### PR TITLE
Load network settings from layout configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Use `Ctrl+C` to stop the sender and demo renderer.
 ## UDP Data Format
 
 Each frame is broken into runs and transmitted to the controllers as UDP datagrams.
-For a given side the destination IP is specified in `sender.config.json` and each run
-is sent to `portBase + run_index`.
+For a given side the layout file defines both the destination IP (`static_ip`) and
+the UDP base port (`port_base`). `sender.config.json` only lists paths to these layout
+files, and each run is sent to `portBase + run_index`.
 
 The UDP payload layout is:
 

--- a/config/demo.config.json
+++ b/config/demo.config.json
@@ -1,77 +1,7 @@
 {
   "sides": {
-    "left": {
-      "ip": "127.0.0.1",
-      "portBase": 49600,
-      "side": "left",
-      "total_leds": 1200,
-      "runs": [
-        {
-          "run_index": 0,
-          "led_count": 400,
-          "sections": [
-            { "id": "row_A1", "led_count": 180, "y": 0.18, "x0": 0.0, "x1": 0.20 },
-            { "id": "row_A2", "led_count": 120, "y": 0.22, "x0": 0.20,  "x1": 1.35 },
-            { "id": "row_A3", "led_count": 100,  "y": 0.26, "x0": 0.75,  "x1": 1.80 }
-          ]
-        },
-        {
-          "run_index": 1,
-          "led_count": 400,
-          "sections": [
-            { "id": "row_B1", "led_count": 140, "y": 0.50, "x0": 0.00,  "x1": 1.00 },
-            { "id": "row_B2", "led_count": 120, "y": 0.55, "x0": 0.60,  "x1": 1.60 },
-            { "id": "row_B3", "led_count": 140, "y": 0.58, "x0": 0.10, "x1": 0.90 }
-          ]
-        },
-        {
-          "run_index": 2,
-          "led_count": 400,
-          "sections": [
-            { "id": "row_C1", "led_count": 150, "y": 0.78, "x0": 0.25,  "x1": 1.30 },
-            { "id": "row_C2", "led_count": 130, "y": 0.82, "x0": 0.00,  "x1": 1.10 },
-            { "id": "row_C3", "led_count": 120, "y": 0.88, "x0": 1.00,  "x1": 2.00 }
-          ]
-        }
-      ],
-      "sampling": { "space": "normalized", "width": 2.0, "height": 1.0 }
-    },
-    "right": {
-      "ip": "127.0.0.1",
-      "portBase": 49610,
-      "side": "right",
-      "total_leds": 1500,
-      "runs": [
-        {
-          "run_index": 0,
-          "led_count": 500,
-          "sections": [
-            { "id": "row_A1", "led_count": 200, "y": 0.12, "x0": 0.05, "x1": 0.85 },
-            { "id": "row_A2", "led_count": 180, "y": 0.18, "x0": 0.90, "x1": 1.70 },
-            { "id": "row_A3", "led_count": 120, "y": 0.24, "x0": 0.20, "x1": 1.50 }
-          ]
-        },
-        {
-          "run_index": 1,
-          "led_count": 500,
-          "sections": [
-            { "id": "row_B1", "led_count": 160, "y": 0.45, "x0": 0.00, "x1": 1.00 },
-            { "id": "row_B2", "led_count": 170, "y": 0.52, "x0": 0.75, "x1": 1.95 },
-            { "id": "row_B3", "led_count": 170, "y": 0.60, "x0": 0.30, "x1": 1.20 }
-          ]
-        },
-        {
-          "run_index": 2,
-          "led_count": 500,
-          "sections": [
-            { "id": "row_C1", "led_count": 190, "y": 0.78, "x0": 0.10, "x1": 1.40 },
-            { "id": "row_C2", "led_count": 160, "y": 0.84, "x0": 0.60, "x1": 1.80 },
-            { "id": "row_C3", "led_count": 150, "y": 0.90, "x0": 1.10, "x1": 2.00 }
-          ]
-        }
-      ],
-      "sampling": { "space": "normalized", "width": 2.0, "height": 1.0 }
-    }
+    "left": "./left.json",
+    "right": "./right.json"
   },
   "renderer": {
     "cmd": "node",

--- a/config/sender.config.json
+++ b/config/sender.config.json
@@ -1,7 +1,7 @@
 {
   "sides": {
-    "left":  { "ip": "10.10.0.2", "portBase": 49600, "layout": "./config/left.json" },
-    "right": { "ip": "10.10.0.3", "portBase": 49610, "layout": "./config/right.json" }
+    "left": "./left.json",
+    "right": "./right.json"
   },
   "renderer": {
     "cmd": "npm",

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -51,17 +51,22 @@ export async function main(argv = process.argv) {
 
     const baseDir = path.dirname(configPath);
     if (config.sides) {
-      for (const [side, cfg] of Object.entries(config.sides)) {
-        if (cfg.layout) {
-          let layoutPath = path.resolve(baseDir, cfg.layout);
-          if (!fs.existsSync(layoutPath)) {
-            layoutPath = path.resolve(process.cwd(), cfg.layout);
-          }
-          const layout = loadLayout(layoutPath, logger);
-          Object.assign(cfg, layout);     // merge runs/total_leds/side into cfg
-          cfg.layout = layout; // keep layout for reference only
-          logger.debug(`Loaded ${side} layout from ${layoutPath}`);
+      for (const [side, layoutRel] of Object.entries(config.sides)) {
+        let layoutPath = path.resolve(baseDir, layoutRel);
+        if (!fs.existsSync(layoutPath)) {
+          layoutPath = path.resolve(process.cwd(), layoutRel);
         }
+        const layout = loadLayout(layoutPath, logger);
+        const sideCfg = {
+          ip: layout.static_ip.join('.'),
+          portBase: layout.port_base,
+          runs: layout.runs,
+          total_leds: layout.total_leds,
+          side: layout.side,
+          layout,
+        };
+        config.sides[side] = sideCfg;
+        logger.debug(`Loaded ${side} layout from ${layoutPath}`);
       }
     }
 

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -2,5 +2,5 @@
 
 Utilities for loading sender configuration and side layout files.
 
-- `load-config.mjs` parses `sender.config.json` and validates renderer, side, and telemetry settings.
-- `load-layout.mjs` reads a layout JSON file and validates its structure.
+- `load-config.mjs` parses `sender.config.json` and validates renderer, layout paths, and telemetry settings.
+- `load-layout.mjs` reads a layout JSON file, validating structure, `port_base`, and `static_ip` used for UDP targets.

--- a/src/config/load-config.mjs
+++ b/src/config/load-config.mjs
@@ -20,21 +20,15 @@ export function loadConfig(configPath) {
     throw new Error('Missing sides configuration');
   }
   const baseDirectory = path.dirname(configPath);
-  for (const [sideName, sideConfig] of Object.entries(parsedConfig.sides)) {
-    if (typeof sideConfig.ip !== 'string') {
-      throw new Error(`side ${sideName} ip must be a string`);
-    }
-    if (typeof sideConfig.portBase !== 'number') {
-      throw new Error(`side ${sideName} portBase must be a number`);
-    }
-    if (typeof sideConfig.layout !== 'string') {
+  for (const [sideName, layoutRelPath] of Object.entries(parsedConfig.sides)) {
+    if (typeof layoutRelPath !== 'string') {
       throw new Error(`side ${sideName} layout must be a string`);
     }
-    let layoutPath = path.resolve(baseDirectory, sideConfig.layout);
+    let layoutPath = path.resolve(baseDirectory, layoutRelPath);
     if (!fs.existsSync(layoutPath)) {
-      layoutPath = path.resolve(process.cwd(), sideConfig.layout);
+      layoutPath = path.resolve(process.cwd(), layoutRelPath);
       if (!fs.existsSync(layoutPath)) {
-        throw new Error(`Layout file not found for side ${sideName}: ${sideConfig.layout}`);
+        throw new Error(`Layout file not found for side ${sideName}: ${layoutRelPath}`);
       }
     }
   }

--- a/src/config/load-layout.mjs
+++ b/src/config/load-layout.mjs
@@ -20,6 +20,18 @@ export function loadLayout(filePath, logger = console) {
   if (!layout || !Array.isArray(layout.runs)) {
     throw new Error('Layout must have a runs array');
   }
+  if (typeof layout.port_base !== 'number') {
+    throw new Error('Layout must include numeric port_base');
+  }
+  if (
+    !Array.isArray(layout.static_ip) ||
+    layout.static_ip.length !== 4 ||
+    !layout.static_ip.every(
+      (octet) => Number.isInteger(octet) && octet >= 0 && octet <= 255,
+    )
+  ) {
+    throw new Error('Layout must include static_ip [a,b,c,d]');
+  }
 
   const runIndices = new Set();
   let totalRunLeds = 0;

--- a/test/cli-config.test.mjs
+++ b/test/cli-config.test.mjs
@@ -38,12 +38,6 @@ test('CLI fails when renderer command is missing', () => {
   assert.strictEqual(result.status, 1);
 });
 
-test('CLI fails when side portBase is not numeric', () => {
-  const badPath = writeTempConfig((cfg) => { cfg.sides.left.portBase = 'abc'; });
-  const result = spawnSync('node', [binaryPath, '--config', badPath], { encoding: 'utf8' });
-  assert.strictEqual(result.status, 1);
-});
-
 test('CLI fails when telemetry interval is non-positive', () => {
   const badPath = writeTempConfig((cfg) => { cfg.telemetry.interval_ms = 0; });
   const result = spawnSync('node', [binaryPath, '--config', badPath], { encoding: 'utf8' });

--- a/test/fixtures/cli_bad_layout.config.json
+++ b/test/fixtures/cli_bad_layout.config.json
@@ -1,7 +1,7 @@
 {
   "sides": {
-    "left": { "ip": "10.10.0.2", "portBase": 49600, "layout": "./layout_duplicate_run.json" },
-    "right": { "ip": "10.10.0.3", "portBase": 49610, "layout": "./layout_duplicate_run.json" }
+    "left": "./layout_duplicate_run.json",
+    "right": "./layout_duplicate_run.json"
   },
   "renderer": { "cmd": "node", "args": ["test/fixtures/renderer_stream.mjs"], "cwd": "." },
   "telemetry": { "interval_ms": 1000, "log_level": "info" }

--- a/test/fixtures/cli_renderer.config.json
+++ b/test/fixtures/cli_renderer.config.json
@@ -1,7 +1,7 @@
 {
   "sides": {
-    "left":  { "ip": "10.10.0.2", "portBase": 49600, "layout": "../../config/left.json" },
-    "right": { "ip": "10.10.0.3", "portBase": 49610, "layout": "../../config/right.json" }
+    "left":  "../../config/left.json",
+    "right": "../../config/right.json"
   },
   "renderer": { "cmd": "node", "args": ["test/fixtures/renderer_stream.mjs"], "cwd": "." },
   "telemetry": { "interval_ms": 1000, "log_level": "info" }

--- a/test/fixtures/layout_bad_sections.json
+++ b/test/fixtures/layout_bad_sections.json
@@ -1,6 +1,8 @@
 {
   "side": "left",
   "total_leds": 100,
+  "static_ip": [10, 10, 0, 2],
+  "port_base": 12345,
   "runs": [
     {
       "run_index": 0,

--- a/test/fixtures/layout_duplicate_run.json
+++ b/test/fixtures/layout_duplicate_run.json
@@ -1,6 +1,8 @@
 {
   "side": "left",
   "total_leds": 100,
+  "static_ip": [10, 10, 0, 2],
+  "port_base": 12345,
   "runs": [
     {
       "run_index": 0,

--- a/test/fixtures/layout_missing_ip.json
+++ b/test/fixtures/layout_missing_ip.json
@@ -1,0 +1,12 @@
+{
+  "side": "left",
+  "total_leds": 20,
+  "port_base": 12345,
+  "runs": [
+    {
+      "run_index": 0,
+      "led_count": 20,
+      "sections": [ { "id": "s1", "led_count": 20 } ]
+    }
+  ]
+}

--- a/test/fixtures/layout_missing_port.json
+++ b/test/fixtures/layout_missing_port.json
@@ -1,0 +1,12 @@
+{
+  "side": "left",
+  "total_leds": 20,
+  "static_ip": [10, 10, 0, 2],
+  "runs": [
+    {
+      "run_index": 0,
+      "led_count": 20,
+      "sections": [ { "id": "s1", "led_count": 20 } ]
+    }
+  ]
+}

--- a/test/fixtures/layout_total_mismatch.json
+++ b/test/fixtures/layout_total_mismatch.json
@@ -1,6 +1,8 @@
 {
   "side": "left",
   "total_leds": 150,
+  "static_ip": [10, 10, 0, 2],
+  "port_base": 12345,
   "runs": [
     {
       "run_index": 0,

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -18,6 +18,7 @@ const leftLayout = JSON.parse(fs.readFileSync(layoutPath, 'utf8'));
 const adaptedSamplePath = createAdaptedSampleFile(layoutPath);
 
 function buildConfig(portBase) {
+  const layout = { ...leftLayout, port_base: portBase };
   return {
     renderer: {
       cmd: process.execPath,
@@ -28,9 +29,9 @@ function buildConfig(portBase) {
     },
     sides: {
       left: {
-        ...leftLayout,
-        ip: '127.0.0.1',
+        ...layout,
         portBase,
+        ip: '127.0.0.1',
       },
     },
   };

--- a/test/layout.test.mjs
+++ b/test/layout.test.mjs
@@ -13,6 +13,8 @@ test('loads valid layout files', () => {
   // primary keys
   assert.strictEqual(typeof layout.side, 'string');
   assert.strictEqual(typeof layout.total_leds, 'number');
+  assert.strictEqual(typeof layout.port_base, 'number');
+  assert.strictEqual(typeof layout.gateway_telemetry_port, 'number');
   assert.ok(Array.isArray(layout.static_ip));
   assert.ok(layout.static_ip.every((octet) => typeof octet === 'number'));
   assert.ok(Array.isArray(layout.static_netmask));
@@ -40,6 +42,16 @@ test('loads valid layout files', () => {
   assert.strictEqual(typeof sampling.space, 'string');
   assert.strictEqual(typeof sampling.width, 'number');
   assert.strictEqual(typeof sampling.height, 'number');
+});
+
+test('throws when port_base is missing', () => {
+  const layoutPath = path.join(__dirname, 'fixtures', 'layout_missing_port.json');
+  assert.throws(() => loadLayout(layoutPath), /port_base/);
+});
+
+test('throws when static_ip is missing', () => {
+  const layoutPath = path.join(__dirname, 'fixtures', 'layout_missing_ip.json');
+  assert.throws(() => loadLayout(layoutPath), /static_ip/);
 });
 
 test('throws when section counts do not match run led_count', () => {


### PR DESCRIPTION
## Summary
- simplify sender.config.json to map sides directly to layout files
- derive each side's IP and base port from layout `static_ip` and `port_base`
- validate `static_ip` in layouts and update tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4945d5bc08322850d0dc8176d1eb6