### PR TITLE
Throttle UDP send error logging

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -69,8 +69,8 @@ export async function main(argv = process.argv) {
     const rp = new RendererProcess(config, logger);
     const assembler = new Assembler(config, logger, mailbox);
     assembler.bindFrameEmitter(rp);
-    const sender = new UdpSender(config, mailbox, logger);
     const telemetry = new Telemetry(config, mailbox, logger);
+    const sender = new UdpSender(config, mailbox, telemetry, logger);
     telemetry.bindRenderer(rp);
     telemetry.bindAssembler(assembler);
 

--- a/src/telemetry/README.md
+++ b/src/telemetry/README.md
@@ -15,6 +15,13 @@ telemetry.start();
 
 Call `stop()` during shutdown to flush the final report.
 
+To throttle repeated errors, call `recordError()` whenever an error occurs. The
+messages are deduplicated and printed with counts below each report.
+
+```javascript
+telemetry.recordError('UDP send error for side left: EHOSTUNREACH');
+```
+
 ## Counters
 
 Per side counters maintained and reported:

--- a/src/udp-sender/README.md
+++ b/src/udp-sender/README.md
@@ -8,10 +8,12 @@ packet for each run within a frame.
 
 ```js
 import { Mailbox } from '../mailbox/index.ts';
+import { Telemetry } from '../telemetry/index.mjs';
 import { UdpSender } from './index.mjs';
 
 const mailbox = new Mailbox();
-const sender = new UdpSender(runtimeConfig, mailbox);
+const telemetry = new Telemetry(runtimeConfig, mailbox);
+const sender = new UdpSender(runtimeConfig, mailbox, telemetry);
 sender.start();
 
 // later when shutting down
@@ -20,4 +22,5 @@ sender.stop();
 
 `UdpSender` calls `mailbox.take(side)` which atomically retrieves the latest
 assembled frame. The mailbox updates telemetry counters (`frames_sent`) when
-frames are consumed.
+frames are consumed. When UDP send errors occur they are passed to the telemetry
+instance which aggregates and prints them below each report.

--- a/src/udp-sender/index.mjs
+++ b/src/udp-sender/index.mjs
@@ -7,11 +7,13 @@ export class UdpSender {
   /**
    * @param {object} runtimeConfig - Loaded sender configuration
    * @param {Mailbox} mailbox - Mailbox instance for retrieving frames
+   * @param {Telemetry} [telemetry] - Telemetry instance for recording errors
    * @param {{error:Function, warn:Function, info:Function, debug:Function}} [logger=console]
    */
-  constructor(runtimeConfig, mailbox, logger = console) {
+  constructor(runtimeConfig, mailbox, telemetry, logger = console) {
     this.config = runtimeConfig;
     this.mailbox = mailbox;
+    this.telemetry = telemetry;
     this.logger = logger;
     this.sockets = {};
     this.timers = {};
@@ -61,9 +63,12 @@ export class UdpSender {
         sideConfig.ip,
         (err) => {
           if (err) {
-            this.logger.error(
-              `UDP send error for side ${sideName}: ${err.message}`,
-            );
+            const msg = `UDP send error for side ${sideName}: ${err.message}`;
+            if (this.telemetry && typeof this.telemetry.recordError === 'function') {
+              this.telemetry.recordError(msg);
+            } else {
+              this.logger.error(msg);
+            }
           }
         },
       );

--- a/test/README.md
+++ b/test/README.md
@@ -17,3 +17,4 @@ Integration and unit tests for the Barn Lights UDP Sender. The tests run with No
 - `integration.test.mjs` runs a mock renderer in a loop and validates the full pipeline through UDP transmission.
 - `layout.test.mjs` checks layout validation.
 - `renderer-process.test.mjs` exercises renderer spawning and NDJSON ingestion.
+- `telemetry-errors.test.mjs` verifies throttled error reporting.

--- a/test/telemetry-errors.test.mjs
+++ b/test/telemetry-errors.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Telemetry } from '../src/telemetry/index.mjs';
+import { Mailbox } from '../src/mailbox/index.mjs';
+
+test('telemetry aggregates repeated errors', () => {
+  const logged = [];
+  const logger = {
+    error: (msg) => logged.push(msg),
+    warn: () => {},
+    info: () => {},
+    debug: () => {},
+  };
+  const config = {
+    sides: {
+      left: { runs: [{ run_index: 0, led_count: 1 }] },
+    },
+    telemetry: { interval_ms: 10 },
+  };
+  const mailbox = new Mailbox();
+  const telemetry = new Telemetry(config, mailbox, logger);
+  telemetry.recordError('test error');
+  telemetry.recordError('test error');
+  telemetry.recordError('another error');
+  telemetry.stop();
+  assert.ok(logged.includes('test error (2x)'));
+  assert.ok(logged.includes('another error (1x)'));
+});


### PR DESCRIPTION
## Summary
- aggregate duplicate UDP send errors and print counts with telemetry reports
- forward send errors from UdpSender to telemetry
- verify error aggregation with new unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f263049483229730818290abe646