### PR TITLE
Track per-second frame counts in telemetry

### DIFF
--- a/src/telemetry/README.md
+++ b/src/telemetry/README.md
@@ -1,6 +1,6 @@
 # Telemetry
 
-The telemetry module gathers runtime statistics from the renderer, assembler and UDP sender.  It listens for events to count frames and periodically prints a summary table.
+The telemetry module gathers runtime statistics from the renderer, assembler and UDP sender. It listens for events to count frames and periodically prints a summary table with per-interval counts.
 
 ## Usage
 
@@ -24,7 +24,7 @@ telemetry.recordError('UDP send error for side left: EHOSTUNREACH');
 
 ## Counters
 
-Per side counters maintained and reported:
+Per side counters maintained and reported (values since the previous report):
 
 - `frames_ingested` – frames received from the renderer.
 - `frames_built` – frames successfully assembled.


### PR DESCRIPTION
## Summary
- compute frame counts based on activity since the previous report
- warn and display drop counts per interval
- document telemetry counters as per-interval values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5f83b115c83229aff099da92522a0