### PR TITLE
Handle renderer reboot frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Offset  Size  Description
 - Controllers should only display a frame after receiving all runs for a side with
   the same `frame_id`; otherwise the last complete frame should remain visible.
 
+### Special Control Frames
+
+The renderer may emit a line such as `{ "reboot": true, "side": "left" }` to
+request that a controller reboot. When received, the sender transmits a single
+byte via UDP to `port_base + 100` for the specified side.
+
 ## Exit Codes
 
 - `0` Normal shutdown.

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -79,6 +79,10 @@ export async function main(argv = process.argv) {
     telemetry.bindRenderer(rp);
     telemetry.bindAssembler(assembler);
 
+    rp.on('Reboot', (sideName) => {
+      sender.sendRebootSignal(sideName);
+    });
+
     rp.on('error', (err) => {
       logger.error(err.message);
       sender.stop();

--- a/src/renderer-process/README.md
+++ b/src/renderer-process/README.md
@@ -1,6 +1,6 @@
 # Renderer Process
 
-Spawns an external renderer and emits `FrameIngest` events for each NDJSON frame produced on stdout. Any output from the renderer is ignored until a line beginning with `{"ts` is received, allowing startup messages to be printed without affecting the stream.
+Spawns an external renderer and emits `FrameIngest` events for each NDJSON frame produced on stdout. Any output from the renderer is ignored until a line beginning with `{"ts` is received, allowing startup messages to be printed without affecting the stream. The module also listens for special control frames like `{ "reboot": true, "side": "left" }` and emits a `Reboot` event with the side name when encountered.
 
 If a working directory (`cwd`) is specified in the renderer configuration, the module verifies that the directory exists before spawning and emits an `error` event if it is missing.
 

--- a/src/renderer-process/index.mjs
+++ b/src/renderer-process/index.mjs
@@ -61,6 +61,13 @@ export class RendererProcess extends EventEmitter {
         this.logger.error(`Failed to parse NDJSON line: ${line}`);
         return;
       }
+      if (parsed.reboot === true && parsed.side) {
+        // Special control frame requesting a controller reboot. Emit a
+        // dedicated event so higher layers can react without trying to
+        // assemble the frame as RGB data.
+        this.emit('Reboot', parsed.side);
+        return;
+      }
       if (parsed.format !== 'rgb8') {
         // The renderer might emit other formats, but for now we only
         // understand "rgb8" frames.

--- a/src/udp-sender/README.md
+++ b/src/udp-sender/README.md
@@ -4,6 +4,9 @@ Fetches frames from the [Mailbox](../mailbox) and sends them to each side's
 controller over UDP. One loop runs per side, polling the mailbox and emitting a
 packet for each run within a frame.
 
+The sender exposes `sendRebootSignal(side)` for emitting a single byte to
+`portBase + 100` when a renderer requests a controller reboot.
+
 ## Usage
 
 ```js

--- a/src/udp-sender/index.mjs
+++ b/src/udp-sender/index.mjs
@@ -43,6 +43,30 @@ export class UdpSender {
   }
 
   /**
+   * Send a single reboot signal to the controller for the given side.
+   * @param {"left"|"right"} sideName
+   */
+  sendRebootSignal(sideName) {
+    const sideConfig = this.config.sides?.[sideName];
+    const socket = this.sockets[sideName];
+    if (!sideConfig || !socket) {
+      return;
+    }
+    const rebootPort = sideConfig.portBase + 100;
+    const message = Buffer.alloc(1);
+    socket.send(message, rebootPort, sideConfig.ip, (err) => {
+      if (err) {
+        const msg = `UDP reboot send error for side ${sideName}: ${err.message}`;
+        if (this.telemetry && typeof this.telemetry.recordError === 'function') {
+          this.telemetry.recordError(msg);
+        } else {
+          this.logger.error(msg);
+        }
+      }
+    });
+  }
+
+  /**
    * Check the mailbox for a frame and send packets for each run.
    * @param {"left"|"right"} sideName
    * @param {object} sideConfig

--- a/test/README.md
+++ b/test/README.md
@@ -7,6 +7,7 @@ Integration and unit tests for the Barn Lights UDP Sender. The tests run with No
 - `renderer_crash.mjs` simulates a renderer that exits with an error.
 - `renderer_loop.mjs` continuously streams frames from `config/input-sample.txt` (or a provided path) for integration testing.
 - `renderer_preamble.mjs` prints startup messages before emitting the first frame to test preamble handling.
+- `renderer_reboot.mjs` emits a reboot control frame after an initial timestamped frame.
 - `decode-sample-frame.mjs` decodes the first sample frame into a run buffer for assertions.
 - `adapt-sample.mjs` rewrites renderer samples so that section lengths match the current layout configuration.
 
@@ -19,3 +20,4 @@ Integration and unit tests for the Barn Lights UDP Sender. The tests run with No
 - `layout.test.mjs` checks layout validation.
 - `renderer-process.test.mjs` exercises renderer spawning and NDJSON ingestion.
 - `telemetry-errors.test.mjs` verifies throttled error reporting.
+- `udp-sender.test.mjs` checks reboot signal transmission.

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -6,5 +6,6 @@ Helper scripts used by the test suite.
 - `renderer_crash.mjs` simulates a renderer that exits with an error.
 - `renderer_loop.mjs` continuously streams frames from a sample NDJSON file.
 - `renderer_preamble.mjs` prints startup messages before emitting the first frame.
+- `renderer_reboot.mjs` outputs a timestamped frame followed by a reboot request frame.
 - `decode-sample-frame.mjs` decodes the first sample frame into a run buffer.
 - `adapt-sample.mjs` rewrites renderer samples so that section lengths match the layout.

--- a/test/fixtures/renderer_reboot.mjs
+++ b/test/fixtures/renderer_reboot.mjs
@@ -1,0 +1,3 @@
+console.log(JSON.stringify({ ts: 0, format: 'rgb8', frame: 1, sides: {} }));
+console.log(JSON.stringify({ reboot: true, side: 'left' }));
+

--- a/test/renderer-process.test.mjs
+++ b/test/renderer-process.test.mjs
@@ -79,3 +79,21 @@ test('emits error when renderer crashes', async () => {
   assert(err instanceof Error);
 });
 
+test('emits reboot events for special frames', async () => {
+  const runtimeConfig = {
+    renderer: {
+      cmd: process.execPath,
+      args: [path.join(__dirname, 'fixtures', 'renderer_reboot.mjs')],
+    },
+  };
+  const logs = [];
+  const logger = { error: (msg) => logs.push(msg), warn() {}, info() {}, debug() {} };
+  const rp = new RendererProcess(runtimeConfig, logger);
+  const receivedSides = [];
+  rp.on('Reboot', (sideName) => receivedSides.push(sideName));
+  const child = rp.start();
+  await new Promise((resolve) => child.on('close', resolve));
+  assert.deepEqual(receivedSides, ['left']);
+  assert.strictEqual(logs.length, 0);
+});
+

--- a/test/udp-sender.test.mjs
+++ b/test/udp-sender.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import dgram from 'dgram';
+import { UdpSender } from '../src/udp-sender/index.mjs';
+import { Mailbox } from '../src/mailbox/index.mjs';
+
+test('sendRebootSignal sends a byte to port base plus one hundred', async () => {
+  const udpServer = dgram.createSocket('udp4');
+  await new Promise((resolve) => udpServer.bind(0, resolve));
+  const rebootPort = udpServer.address().port;
+  const portBase = rebootPort - 100;
+  const runtimeConfig = {
+    sides: {
+      left: { ip: '127.0.0.1', portBase, runs: [] },
+    },
+  };
+  const mailbox = new Mailbox();
+  const sender = new UdpSender(runtimeConfig, mailbox);
+  sender.start();
+  const received = new Promise((resolve) => {
+    udpServer.once('message', (msg) => resolve(msg));
+  });
+  sender.sendRebootSignal('left');
+  const message = await received;
+  assert.strictEqual(message.length, 1);
+  sender.stop();
+  udpServer.close();
+});


### PR DESCRIPTION
## Summary
- emit `Reboot` events for special renderer frames `{reboot:true, side}`
- add `sendRebootSignal` to UDP sender and wire from CLI
- document and test reboot signalling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b68f3012548322aa6110a24733c079