### PR TITLE
Add session identifier to UDP packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,21 @@ The UDP payload layout is:
 
 ```
 Offset  Size  Description
-0       4     frame_id (unsigned 32-bit big-endian)
-4       N     RGB data for the run (run_led_count * 3 bytes)
+0       2     session_id (unsigned 16-bit big-endian)
+2       4     frame_id (unsigned 32-bit big-endian)
+6       N     RGB data for the run (run_led_count * 3 bytes)
 ```
 
 - RGB bytes are in physical LED order with one 8-bit value for each of red, green
   and blue.
+- The `session_id` is a randomly generated unsigned 16-bit value when the
+  sender process starts and remains constant for all packets until the process
+  exits.
 - The `frame_id` matches the `frame` value emitted by the renderer and wraps at
   2^32.
 - Controllers should only display a frame after receiving all runs for a side with
-  the same `frame_id`; otherwise the last complete frame should remain visible.
+  the same `session_id` and `frame_id`; otherwise the last complete frame should
+  remain visible.
 
 ### Special Control Frames
 

--- a/src/udp-sender/index.mjs
+++ b/src/udp-sender/index.mjs
@@ -1,4 +1,5 @@
 import dgram from 'dgram';
+import { randomBytes } from 'crypto';
 
 /**
  * UdpSender polls the mailbox for assembled frames and sends them via UDP.
@@ -17,6 +18,7 @@ export class UdpSender {
     this.logger = logger;
     this.sockets = {};
     this.timers = {};
+    this.sessionId = randomBytes(2).readUInt16BE(0);
   }
 
   /** Start polling loops for all configured sides. */
@@ -78,8 +80,9 @@ export class UdpSender {
       return;
     }
     for (const run of frame.runs) {
-      const header = Buffer.alloc(4);
-      header.writeUInt32BE(frame.frame_id >>> 0, 0);
+      const header = Buffer.alloc(6);
+      header.writeUInt16BE(this.sessionId, 0);
+      header.writeUInt32BE(frame.frame_id >>> 0, 2);
       const packet = Buffer.concat([header, run.data]);
       socket.send(
         packet,

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -79,13 +79,15 @@ test('udp sender transmits packets for assembled frames', async () => {
   udpServer.close();
 
   assert(receivedPackets.length > 0, 'expected at least one UDP packet');
-  const expectedLength = 4 + leftLayout.runs[0].led_count * 3;
+  const expectedLength = 6 + leftLayout.runs[0].led_count * 3;
   const firstPacket = receivedPackets[0];
   assert.strictEqual(firstPacket.length, expectedLength);
   const expected = decodeSampleFrame(layoutPath, adaptedSamplePath);
-  const frameId = firstPacket.readUInt32BE(0);
+  const sessionId = firstPacket.readUInt16BE(0);
+  assert.strictEqual(sessionId, sender.sessionId, 'session id header mismatch');
+  const frameId = firstPacket.readUInt32BE(2);
   assert.strictEqual(frameId, expected.frameId, 'frame id header mismatch');
-  const rgbPayload = firstPacket.subarray(4);
+  const rgbPayload = firstPacket.subarray(6);
   assert.ok(
     expected.buffer.equals(rgbPayload),
     'RGB payload does not match renderer output',

--- a/test/udp-sender.test.mjs
+++ b/test/udp-sender.test.mjs
@@ -26,3 +26,40 @@ test('sendRebootSignal sends a byte to port base plus one hundred', async () => 
   sender.stop();
   udpServer.close();
 });
+
+test('packets prefix RGB data with session and frame identifiers', async () => {
+  const udpServer = dgram.createSocket('udp4');
+  await new Promise((resolve) => udpServer.bind(0, resolve));
+  const runPort = udpServer.address().port;
+  const runtimeConfig = {
+    sides: {
+      left: {
+        ip: '127.0.0.1',
+        portBase: runPort,
+        runs: [{ run_index: 0, led_count: 1 }],
+      },
+    },
+  };
+  const mailbox = new Mailbox();
+  const sender = new UdpSender(runtimeConfig, mailbox);
+
+  const payloadPromise = new Promise((resolve) => {
+    udpServer.once('message', (msg) => resolve(msg));
+  });
+
+  const frame = {
+    frame_id: 123,
+    runs: [{ run_index: 0, data: Buffer.from([1, 2, 3]) }],
+  };
+  mailbox.write('left', frame);
+  sender.start();
+
+  const message = await payloadPromise;
+  assert.strictEqual(message.length, 6 + frame.runs[0].data.length);
+  assert.strictEqual(message.readUInt16BE(0), sender.sessionId);
+  assert.strictEqual(message.readUInt32BE(2), frame.frame_id);
+  assert.deepStrictEqual(message.subarray(6), frame.runs[0].data);
+
+  sender.stop();
+  udpServer.close();
+});

--- a/udp-data-format.md
+++ b/udp-data-format.md
@@ -1,0 +1,30 @@
+# UDP Data Format
+
+Each run within a frame is transmitted as a UDP datagram. The destination IP and
+base port (`portBase`) are configured per side; the sender transmits each run to
+`portBase + run_index`.
+
+## Payload Layout
+
+```
+Offset  Size  Description
+0       2     session_id (unsigned 16-bit big-endian)
+2       4     frame_id (unsigned 32-bit big-endian)
+6       N     RGB data for the run (run_led_count * 3 bytes)
+```
+
+- `session_id` is randomly generated as an unsigned 16-bit value when the sender
+  process starts and remains constant until the process shuts down. Firmware can
+  use this value to detect when the sender has restarted and reset any
+  per-session state.
+- `frame_id` matches the `frame` value emitted by the renderer (u32, wrapping at
+  2^32). Controllers should only display a frame after receiving all runs for a
+  side with the same `session_id` and `frame_id`.
+- The RGB bytes are ordered physically with one byte each for red, green, and
+  blue per LED.
+
+## Reboot Signal
+
+When the renderer emits `{ "reboot": true, "side": "left" }`, the sender
+transmits a single zero byte to `portBase + 100` for the specified side. The
+reboot packet does not include a session or frame identifier.


### PR DESCRIPTION
## Summary
- prepend a randomly generated 16-bit session identifier to every UDP frame header
- extend automated tests to validate the session header and updated packet sizing
- document the revised payload structure, including a dedicated udp-data-format guide

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d02310b4108322918653bfd3f784c4